### PR TITLE
Fix EZP-26300: Fatal error when going through defaultExceptionHandler with PHP7

### DIFF
--- a/lib/ezutils/classes/ezexecution.php
+++ b/lib/ezutils/classes/ezexecution.php
@@ -174,10 +174,10 @@ class eZExecution
     /**
      * Installs the default Exception handler
      *
-     * @params Exception the exception
+     * @params Exception|Throwable the exception
      * @return void
      */
-    static public function defaultExceptionHandler( Throwable $e )
+    static public function defaultExceptionHandler( $e )
     {
         if( PHP_SAPI != 'cli' )
         {


### PR DESCRIPTION
Fix EZP-26300: Fatal error when going through defaultExceptionHandler with PHP7

> https://jira.ez.no/browse/EZP-26300

With PHP 7, exception handlers can now receive `Error` exceptions. Those exceptions are internal to PHP and are not directly linked to `Exception` class, except that they both implement `Throwable` interface, which is present in PHP 7 only.

This patch just removes `Exception` type hint in `eZExecution::defaultExceptionHandler()` in order to avoid fatal errors when receiving the new `Error` exceptions.
# Conflicts:
#	lib/ezutils/classes/ezexecution.php